### PR TITLE
fix: cleanup readmes for various actions

### DIFF
--- a/actions/aws-cognito-info/README.md
+++ b/actions/aws-cognito-info/README.md
@@ -38,7 +38,7 @@ jobs:
       # Step 2: Run the AWS Cognito Information action
       - name: Get AWS Cognito Information
         id: cognito-info
-        uses: ingeno/foundation-github-actions/actions/aws-cognito-information-action@v2
+        uses: ingeno/foundation-github-actions/actions/aws-cognito-info@<latest>
         with:
           aws-region: ca-central-1
 
@@ -54,3 +54,4 @@ jobs:
 ## Notes
 
 - Before using this action, ensure that you have set up the necessary AWS credentials to access AWS Cognito (e.g. by using the `configure-aws-credentials` action).
+- To see what the current latest version of this action is, head over to this repository's [release page](https://github.com/ingeno/foundation-github-actions/releases).

--- a/actions/aws-docker-tag/README.md
+++ b/actions/aws-docker-tag/README.md
@@ -34,7 +34,7 @@ jobs:
       # Step 2: Run the Tag Docker Image action
       - name: Tag Docker Image
         id: tag-docker-image
-        uses: ingeno/foundation-github-actions/actions/tag-docker-image-action@v3
+        uses: ingeno/foundation-github-actions/actions/aws-docker-tag@<latest>
         with:
           repository: my-ecr-repo
           sourceTag: latest
@@ -52,3 +52,4 @@ jobs:
 ## Notes
 
 - Before using this action, ensure that you have set up the necessary AWS credentials to authenticate with the AWS ECR (e.g. by using the `configure-aws-credentials` action).
+- To see what the current latest version of this action is, head over to this repository's [release page](https://github.com/ingeno/foundation-github-actions/releases).

--- a/actions/aws-s3-deploy-app/README.md
+++ b/actions/aws-s3-deploy-app/README.md
@@ -34,7 +34,7 @@ jobs:
       # Step 2: Run the Deploy App to S3 action
       - name: Deploy App to S3
         id: deploy-to-s3
-        uses: ingeno/foundation-github-actions/actions/deploy-app-to-s3-action@v3
+        uses: ingeno/foundation-github-actions/actions/aws-s3-deploy-app@<latest>
         with:
           aws-region: ca-central-1
           aws-s3-bucket: my-s3-bucket
@@ -52,3 +52,4 @@ jobs:
 ## Notes
 
 - Before using this action, ensure that you have set up the necessary AWS credentials to authenticate with the AWS S3 (e.g. by using the `configure-aws-credentials` action).
+- To see what the current latest version of this action is, head over to this repository's [release page](https://github.com/ingeno/foundation-github-actions/releases).

--- a/actions/configure-aws-credentials/README.md
+++ b/actions/configure-aws-credentials/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The "Configure AWS Credentials" GitHub Action sets up AWS credentials for GitHub OIDC (OpenID Connect) to interact with AWS services using the specified AWS account and region. This action assumes the presence of a role named "AWSGitHubActionRoleForCICD," which is defined by the `@ingeno/aws-cdk-constructs` library.
+The "Configure AWS Credentials" GitHub Action sets up AWS credentials for GitHub OIDC (OpenID Connect) to interact with AWS services using the specified AWS account and region. This action assumes the presence of a role named "AWSGitHubActionRoleForCICD," which is defined by the `@ingeno/foundation-infra-aws` library.
 
 ## Inputs
 

--- a/actions/configure-aws-credentials/README.md
+++ b/actions/configure-aws-credentials/README.md
@@ -32,7 +32,7 @@ jobs:
       # Step 2: Run the Configure AWS Credentials action
       - name: Configure AWS Credentials
         id: configure-aws-credentials
-        uses: ingeno/foundation-github-actions/actions/configure-aws-credentials-action@v3
+        uses: ingeno/foundation-github-actions/actions/configure-aws-credentials@<latest>
         with:
           aws-account-id: 123456789012
           aws-region: ca-central-1
@@ -49,3 +49,4 @@ jobs:
 
 - Before using this action, ensure that you have set up the necessary AWS credentials with sufficient permissions to assume the role "AWSGitHubActionRoleForCICD."
 - The action uses the `aws-actions/configure-aws-credentials@v2` action to set up the AWS credentials for OIDC.
+- To see what the current latest version of this action is, head over to this repository's [release page](https://github.com/ingeno/foundation-github-actions/releases).

--- a/actions/configure-aws-credentials/action.yml
+++ b/actions/configure-aws-credentials/action.yml
@@ -16,6 +16,6 @@ runs:
     - name: Configure Aws Credentials for GitHub OIDC
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        # the role AWSGitHubActionRoleForCICD is defined by @ingeno/aws-cdk-constructs
+        # the role AWSGitHubActionRoleForCICD is defined by @ingeno/foundation-infra-aws
         role-to-assume: arn:aws:iam::${{ inputs.aws-account-id }}:role/AWSGitHubActionRoleForCICD
         aws-region: ${{ inputs.aws-region }}

--- a/actions/docker-deploy/README.md
+++ b/actions/docker-deploy/README.md
@@ -36,7 +36,7 @@ jobs:
       # Step 2: Run the Docker Deploy action
       - name: Docker Deploy
         id: docker-deploy
-        uses: ingeno/foundation-github-actions/actions/docker-deploy-action@v3
+        uses: ingeno/foundation-github-actions/actions/docker-deploy@<latest>
         with:
           registry: your-container-registry.example.com
           repository: my-docker-repo
@@ -56,3 +56,4 @@ jobs:
 ## Notes
 
 - Before using this action, ensure that you have set up the necessary credentials to authenticate with the container image registry by setting the `SHARED_SERVICES_ACCOUNT_ID` variable in your repository.
+- To see what the current latest version of this action is, head over to this repository's [release page](https://github.com/ingeno/foundation-github-actions/releases).

--- a/actions/docker-deploy/README.md
+++ b/actions/docker-deploy/README.md
@@ -12,7 +12,7 @@ The "Docker Deploy" GitHub Action automates the process of building, tagging, an
 
 3. `tag` (optional, type: string): The tag of the built image. If not provided, the default value is "dev".
 
-4. `dockerfile` (optional, type: string): The location of the Dockerfile used to build the Docker image. If not provided, the default value is "dockerfile.yml".
+4. `dockerfile` (optional, type: string): The location of the Dockerfile used to build the Docker image. If not provided, the default value is "Dockerfile".
 
 ## Workflow Example
 

--- a/actions/docker-deploy/action.yml
+++ b/actions/docker-deploy/action.yml
@@ -17,7 +17,7 @@ inputs:
 
   dockerfile:
     required: false
-    default: dockerfile.yml
+    default: Dockerfile
     description: Location of the dockerfile
 
 runs:

--- a/actions/mend-scan/README.md
+++ b/actions/mend-scan/README.md
@@ -23,7 +23,7 @@ jobs:
         uses: ingeno/aws-workflows/.github/actions/node-setup@v1
 
       - name: Mend Scanner
-        uses: ingeno/mend-scan-action@v1
+        uses: ingeno/mend-scan@<latest>
         with:
           api-key: ${{secrets.WS_APIKEY}}
           product-token: ${{secrets.WS_PRODUCTTOKEN}}
@@ -59,3 +59,7 @@ npm.projectNameFromDependencyFile=true
 For more details on the parameters available and their functions, please visit the Mend documentation for [Unified Agent Configuration Parameters](https://docs.mend.io/bundle/unified_agent/page/unified_agent_configuration_parameters.html).
 
 Note: In order to use the parameter `npm.projectNameFromDependencyFile=true` along with the `projectPerFolder=true`, you need to explicitly declare the version of each of the sub-projects in their corresponding `package.json` file.
+
+### Notes
+
+To see what the current latest version of this action is, head over to this repository's [release page](https://github.com/ingeno/foundation-github-actions/releases).

--- a/actions/node-setup/README.md
+++ b/actions/node-setup/README.md
@@ -30,7 +30,7 @@ jobs:
       # Step 2: Run the Node Setup action
       - name: Node Setup
         id: node-setup
-        uses: ingeno/foundation-github-actions/actions/node-setup/node-setup-action@v3
+        uses: ingeno/foundation-github-actions/actions/node-setup/node-setup@<latest>
         with:
           working-directory: my-project-directory
 
@@ -47,4 +47,5 @@ jobs:
 - The action uses `actions/setup-node@v3` to set up the specified Node.js version using the `.nvmrc` file.
 - It then caches the Yarn cache directory using `actions/cache@v3` to speed up future installations.
 - The action finally installs the project dependencies using Yarn with the `yarn install --immutable` command.
+- To see what the current latest version of this action is, head over to this repository's [release page](https://github.com/ingeno/foundation-github-actions/releases).
 


### PR DESCRIPTION
- Use generic `<latest>` version tag in usage examples.
- Fix some wrong action names in usage examples (e.g. extra `-action` in some action names).