### PR TITLE
feat: add local-directory param to aws-s3-deploy action

### DIFF
--- a/actions/aws-s3-deploy-app/README.md
+++ b/actions/aws-s3-deploy-app/README.md
@@ -10,7 +10,7 @@ The "Deploy App to S3" GitHub Action automates the process of uploading a build 
 
 2. `aws-s3-bucket` (required, type: string): The name of the AWS S3 bucket where the build app will be deployed.
 
-2. `local-directory` (optional, type: string): The path of the local directory to upload. The default value is "./frontend/admin/dist".
+2. `local-directory` (optional, type: string): The path of the local directory to upload. The default value is "./frontend/dist".
 
 3. `destination` (optional, type: string): The directory inside the S3 bucket where the build artifacts will be uploaded. The default value is "build".
 

--- a/actions/aws-s3-deploy-app/README.md
+++ b/actions/aws-s3-deploy-app/README.md
@@ -10,7 +10,7 @@ The "Deploy App to S3" GitHub Action automates the process of uploading a build 
 
 2. `aws-s3-bucket` (required, type: string): The name of the AWS S3 bucket where the build app will be deployed.
 
-2. `local-directory` (required, type: string): The path of the local directory to upload.
+2. `local-directory` (optional, type: string): The path of the local directory to upload. The default value is "./frontend/admin/dist".
 
 3. `destination` (optional, type: string): The directory inside the S3 bucket where the build artifacts will be uploaded. The default value is "build".
 

--- a/actions/aws-s3-deploy-app/README.md
+++ b/actions/aws-s3-deploy-app/README.md
@@ -10,6 +10,8 @@ The "Deploy App to S3" GitHub Action automates the process of uploading a build 
 
 2. `aws-s3-bucket` (required, type: string): The name of the AWS S3 bucket where the build app will be deployed.
 
+2. `local-directory` (required, type: string): The path of the local directory to upload.
+
 3. `destination` (optional, type: string): The directory inside the S3 bucket where the build artifacts will be uploaded. The default value is "build".
 
 ## Workflow Example
@@ -39,6 +41,7 @@ jobs:
           aws-region: ca-central-1
           aws-s3-bucket: my-s3-bucket
           destination: my-build-directory
+          local-directory: ./my-app/dist
 
       # Step 3: Optionally use the outputs in subsequent steps (example)
       - name: Display Deployment Details

--- a/actions/aws-s3-deploy-app/action.yml
+++ b/actions/aws-s3-deploy-app/action.yml
@@ -11,8 +11,8 @@ inputs:
     description: The name of the s3 bucket
 
   local-directory:
-    required: true
     description: The local directory to upload
+    default: ./frontend/admin/dist
 
   destination:
     description: The directory inside of the S3 bucket

--- a/actions/aws-s3-deploy-app/action.yml
+++ b/actions/aws-s3-deploy-app/action.yml
@@ -10,6 +10,10 @@ inputs:
     required: true
     description: The name of the s3 bucket
 
+  local-directory:
+    required: true
+    description: The local directory to upload
+
   destination:
     description: The directory inside of the S3 bucket
     default: build
@@ -20,7 +24,7 @@ runs:
     - name: Upload to S3 Bucket (without index.html)
       shell: bash
       run: |
-        aws s3 sync ./frontend/admin/dist s3://${{ inputs.aws-s3-bucket }}/${{ inputs.destination }} \
+        aws s3 sync ${{ inputs.local-directory }} s3://${{ inputs.aws-s3-bucket }}/${{ inputs.destination }} \
                 --region ${{ inputs.aws-region }} \
                 --no-progress \
                 --follow-symlinks \
@@ -31,6 +35,6 @@ runs:
     - name: Upload index.html to S3 Bucket
       shell: bash
       run: |
-        aws s3 cp ./frontend/admin/dist/index.html s3://${{ inputs.aws-s3-bucket }}/${{ inputs.destination }}/index.html \
+        aws s3 cp ${{ inputs.local-directory }}/index.html s3://${{ inputs.aws-s3-bucket }}/${{ inputs.destination }}/index.html \
                 --region ${{ inputs.aws-region }} \
                 --cache-control max-age=0 \

--- a/actions/aws-s3-deploy-app/action.yml
+++ b/actions/aws-s3-deploy-app/action.yml
@@ -12,7 +12,7 @@ inputs:
 
   local-directory:
     description: The local directory to upload
-    default: ./frontend/admin/dist
+    default: ./frontend/dist
 
   destination:
     description: The directory inside of the S3 bucket


### PR DESCRIPTION
Our foundation-templates project does not use the `/frontend` directory for its web app, and instead uses `/web`, so we needed a way to configure this path in the `aws-s3-deploy-app` action if we wanted to use this action.