### PR TITLE
fix: pass npm token along as docker secret

### DIFF
--- a/.github/workflows/aws-docker-deploy.md
+++ b/.github/workflows/aws-docker-deploy.md
@@ -1,4 +1,4 @@
-# AWS Docker Deploy GitHub Action
+# AWS Docker Deploy GitHub Workflow
 
 ## Description
 
@@ -17,6 +17,8 @@ To use this GitHub Action, you need to define it in your workflow file (e.g., `.
 3. `client-environment-file-path` (optional, type: string): The location of the `.env` file for the front-end client, if applicable. This file is used to configure environment variables for the client application.
 
 4. `dotenv-value` (optional, type: string): The value needed to fill the `.env` file for the front-end client. This input is only relevant if `client-environment-file-path` is provided.
+
+5. `npm-read-packages-token` (optional, type: string): Token for reading NPM packages from private repositories
 
 ### Permissions
 

--- a/.github/workflows/aws-docker-deploy.yml
+++ b/.github/workflows/aws-docker-deploy.yml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
         description: The value needed to fill the .env
+      npm-read-packages-token:
+        required: false
+        type: string
+        description: Token for reading NPM packages from private repositories
 
 # These permissions are needed to interact with GitHub's OIDC Token endpoint.
 permissions:
@@ -54,9 +58,10 @@ jobs:
           cat ${{ inputs.client-environment-file-path }}
 
       - name: Build, tag and Push image
-        uses: ingeno/foundation-github-actions/actions/docker-deploy@v3
+        uses: ingeno/foundation-github-actions/actions/docker-deploy@v4
         with:
           registry: ${{ vars.SHARED_SERVICES_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
           repository: ${{ inputs.repository }}
           tag: ${{ github.sha }}
           dockerfile: ${{ inputs.dockerfile }}
+          npm_read_packages_token: ${{ inputs.npm_read_packages_token }}

--- a/actions/docker-deploy/README.md
+++ b/actions/docker-deploy/README.md
@@ -14,6 +14,8 @@ The "Docker Deploy" GitHub Action automates the process of building, tagging, an
 
 4. `dockerfile` (optional, type: string): The location of the Dockerfile used to build the Docker image. If not provided, the default value is "Dockerfile".
 
+5. `npm-read-packages-token` (optional, type: string): Token for reading NPM packages from private repositories
+
 ## Workflow Example
 
 ```yaml
@@ -42,6 +44,7 @@ jobs:
           repository: my-docker-repo
           tag: v1.0.1
           dockerfile: path/to/Dockerfile
+          npm-read-packages-token: secret-token-used-to-access-private-package-repositories
 
       # Step 3: Optionally use the outputs in subsequent steps (example)
       - name: Display Docker Image Details

--- a/actions/docker-deploy/action.yml
+++ b/actions/docker-deploy/action.yml
@@ -20,6 +20,11 @@ inputs:
     default: Dockerfile
     description: Location of the dockerfile
 
+  npm-read-packages-token:
+    required: false
+    default: ''
+    description: Token for reading NPM packages from private repositories
+
 runs:
   using: 'composite'
   steps:
@@ -28,6 +33,8 @@ runs:
       id: docker_setup
       env:
         IMAGE_TAG: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.tag }}
+        NPM_READ_PACKAGES_TOKEN: ${{ inputs.npm-read-packages-token }}
+        DOCKER_BUILDKIT: '1'
       run: |
-        docker build -f ${{ inputs.dockerfile }} -t $IMAGE_TAG .
+        docker build -f ${{ inputs.dockerfile }} -t $IMAGE_TAG --secret id=npm_read_packages_token,env=NPM_READ_PACKAGES_TOKEN .
         docker push $IMAGE_TAG


### PR DESCRIPTION
Since the authentication library is the first ingeno library to be used as a dependency (and not a devDependency), it is now required to pass the NPM token to the docker image for it to be able to build. Following https://pythonspeed.com/articles/docker-build-secrets/, it is passed using buildkit and --secret param. It is supposed to be available on the latest docker. I assume the docker used by github actions is the latest

Afterwards, I will modify the foundation-templates repository to use the new action and read the token in the backend docker file