### PR TITLE
feat: add working directory input to docker deploy workflow

### DIFF
--- a/.github/workflows/aws-docker-deploy.md
+++ b/.github/workflows/aws-docker-deploy.md
@@ -18,6 +18,8 @@ To use this GitHub Action, you need to define it in your workflow file (e.g., `.
 
 4. `dotenv-value` (optional, type: string): The value needed to fill the `.env` file for the front-end client. This input is only relevant if `client-environment-file-path` is provided.
 
+5. `working-directory` (optional, type: string): The current working directory to run the docker command in. If not provided, the default value is `./`.
+
 ### Secrets
 
 1. `NPM_READ_PACKAGES_TOKEN` (optional, type: string): Token for reading NPM packages from private repositories

--- a/.github/workflows/aws-docker-deploy.yml
+++ b/.github/workflows/aws-docker-deploy.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         description: The value needed to fill the .env
+      working-directory:
+        required: false
+        type: string
+        default: ./
+        description: The current working directory to run the commands in
 
 # These permissions are needed to interact with GitHub's OIDC Token endpoint.
 permissions:
@@ -52,12 +57,15 @@ jobs:
           echo -e "${{ inputs.dotenv-value }}" > ${{ inputs.client-environment-file-path }}
           echo ".env created!"
           cat ${{ inputs.client-environment-file-path }}
+        working-directory: ${{ inputs.working-directory }}
+
 
       - name: Build, tag and Push image
-        uses: ingeno/foundation-github-actions/actions/docker-deploy@v4
+        uses: ingeno/foundation-github-actions/actions/docker-deploy@v5
         with:
           registry: ${{ vars.SHARED_SERVICES_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
           repository: ${{ inputs.repository }}
           tag: ${{ github.sha }}
           dockerfile: ${{ inputs.dockerfile }}
           npm-read-packages-token: ${{ secrets.NPM_READ_PACKAGES_TOKEN }}
+          working-directory: ${{ inputs.working-directory }}

--- a/actions/docker-deploy/README.md
+++ b/actions/docker-deploy/README.md
@@ -16,6 +16,8 @@ The "Docker Deploy" GitHub Action automates the process of building, tagging, an
 
 5. `npm-read-packages-token` (optional, type: string): Token for reading NPM packages from private repositories
 
+6. `working-directory` (optional, type: string): The current working directory to run the docker command in. If not provided, the default value is `./`.
+
 ## Workflow Example
 
 ```yaml
@@ -45,6 +47,7 @@ jobs:
           tag: v1.0.1
           dockerfile: path/to/Dockerfile
           npm-read-packages-token: secret-token-used-to-access-private-package-repositories
+          working-direcotry: some/sub/project/directory
 
       # Step 3: Optionally use the outputs in subsequent steps (example)
       - name: Display Docker Image Details

--- a/actions/docker-deploy/action.yml
+++ b/actions/docker-deploy/action.yml
@@ -25,12 +25,18 @@ inputs:
     default: ''
     description: Token for reading NPM packages from private repositories
 
+  working-directory:
+    required: false
+    default: ./
+    description: The current working directory to run the docker command in
+
 runs:
   using: 'composite'
   steps:
     - name: Build, tag and push image
       shell: bash
       id: docker_setup
+      working-directory: ${{ inputs.working-directory }}
       env:
         IMAGE_TAG: ${{ inputs.registry }}/${{ inputs.repository }}:${{ inputs.tag }}
         NPM_READ_PACKAGES_TOKEN: ${{ inputs.npm-read-packages-token }}


### PR DESCRIPTION
This is required to deploy demos, which are in a subdirectory of the `foundation-templates` repository.