### PR TITLE
fix: make repository public again

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,6 +11,7 @@ repository:
   name: foundation-github-actions
   description: This repository provides GitHub Actions, composite actions and reusable workflows for Ingeno repositories
   topics: greenfield, architecture, foundation
+  private: false
   is_template: false
   default_branch: main
   allow_auto_merge: true


### PR DESCRIPTION
The repository was mistakenly set to private by inheriting configs from https://github.com/ingeno/.github/blob/main/.github/_customers.yml, which is breaking our workflows.

<img width="772" alt="image" src="https://github.com/ingeno/foundation-github-actions/assets/44675437/0bbb6029-2071-4f97-b7b3-c16f44b2200d">
