### PR TITLE
feat: expose new input variable for tag

### DIFF
--- a/.github/workflows/aws-docker-deploy.yml
+++ b/.github/workflows/aws-docker-deploy.yml
@@ -24,6 +24,11 @@ on:
         type: string
         default: ./
         description: The current working directory to run the commands in
+      tag:
+        required: false
+        type: string
+        default: ${{ github.sha }}
+        description: The tag to use for the Docker image
 
 # These permissions are needed to interact with GitHub's OIDC Token endpoint.
 permissions:
@@ -65,7 +70,7 @@ jobs:
         with:
           registry: ${{ vars.SHARED_SERVICES_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com
           repository: ${{ inputs.repository }}
-          tag: ${{ github.sha }}
+          tag: ${{ inputs.tag }}
           dockerfile: ${{ inputs.dockerfile }}
           npm-read-packages-token: ${{ secrets.NPM_READ_PACKAGES_TOKEN }}
           working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Allow the action caller to specify an image tag instead of always assigning the commit sha. This is needed for our web-client image since, unlike our api image, it requires a unique image for each environment due to Next.js's way of handling .env files and environment variables in general. See [here](https://github.com/vercel/next.js/tree/canary/examples/with-docker-multi-env) for an official example from Next.js.