### PR TITLE
chore: include chores in changelog

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,26 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+  "changelogPreset": {
+    "name": "conventionalcommits",
+    "types": [
+      {
+        "type": "chore",
+        "section": "Maintenance"
+      },
+      {
+        "type": "fix",
+        "section": "Bug Fixes"
+      },
+      {
+        "type": "feat",
+        "section": "Features"
+      },
+      {
+        "type": "revert",
+        "section": "Reverts"
+      }
+    ]
+  },
   "command": {
     "version": {
       "conventionalCommits": true,


### PR DESCRIPTION
Chore commits were not included in the changelog by default. This config change adds a Maintenance section to the changelog. The rest of the config is just repetition of the default, which I must do because I can't just append to the default config, I have to replace the whole thing, hence the need to repeat the defaults for fixes, features and reverts